### PR TITLE
Fixed using proxy.

### DIFF
--- a/linkedin_api/client.py
+++ b/linkedin_api/client.py
@@ -53,7 +53,7 @@ class Client(object):
         self.session = requests.session()
         self.session.proxies.update(proxies)
         self.session.headers.update(Client.REQUEST_HEADERS)
-
+        self.proxies = proxies
         self.logger = logger
         self._use_cookie_cache = not refresh_cookies
         logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
@@ -75,6 +75,7 @@ class Client(object):
         res = requests.get(
             f"{Client.AUTH_BASE_URL}/uas/authenticate",
             headers=Client.AUTH_REQUEST_HEADERS,
+            proxies=self.proxies
         )
 
         return res.cookies
@@ -113,6 +114,7 @@ class Client(object):
             data=payload,
             cookies=self.session.cookies,
             headers=Client.AUTH_REQUEST_HEADERS,
+            proxies=self.proxies
         )
 
         data = res.json()

--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -33,7 +33,7 @@ class Linkedin(object):
         200
     )  # VERY conservative max requests count to avoid rate-limit
 
-    def __init__(self, username, password, *, refresh_cookies=False, debug=False, proxies=proxies):
+    def __init__(self, username, password, *, refresh_cookies=False, debug=False, proxies={}):
         self.client = Client(refresh_cookies=refresh_cookies, debug=debug, proxies=proxies)
         self.client.authenticate(username, password)
         logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)


### PR DESCRIPTION
Proxies are used during registration.
 For example, in Russia Linked is blocked so it is necessary to register.
 Also, in __init__ Linkedin replaced nonexistent variable proxies for an empty dictionary.