### PR TITLE
Add get_job_posting 

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -35,6 +35,7 @@ Where it all begins. Create an instance of `Linkedin` to get started. You'll aut
 
 - [`linkedin.get_school`](#get_school)
 - [`linkedin.get_company`](#get_company)
+- [`linkedin.get_job_posting`](#get_job_posting)
 
 - [`linkedin.search`](#search)
 - [`linkedin.search_people`](#search_people)
@@ -215,6 +216,29 @@ Returns a company's Linkedin profile.
 linkedin = Linkedin(credentials['username'], credentials['password'])
 
 company = linkedin.get_company('linkedin')
+```
+
+---
+<a name="get_job_posting"></a>
+
+### linkedin.get_job_posting(job_urn_id)
+
+Returns job posting details. The job_urn_id can be found in the "jobPosting" fields in the response of a [`linkedin.search`](#search) for job postings, (i.e, with query param decoration_id=com.linkedin.voyager.deco.jobs.web.shared.WebFullJobPosting-39).
+
+**Arguments**
+
+- `job_urn_id <str>` - job id, e.g: '1792209257'
+
+**Return**
+
+- `<dict>`
+
+**Example**
+
+```python
+linkedin = Linkedin(credentials['username'], credentials['password'])
+
+job_posting = linkedin.get_job_posting('1754968923")
 ```
 
 ---

--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -517,6 +517,24 @@ class Linkedin(object):
 
         return company
 
+    def get_job_posting(self, job_id):
+        """
+        Return job posting details for a given [job_id], e.g: 1677638156
+        """
+
+        params = {'decorationId': 'com.linkedin.voyager.deco.jobs.web.shared.WebFullJobPosting-39', 'topN': '1',
+                  'topNRequestedFlavors': 'List(IN_NETWORK,COMPANY_RECRUIT,SCHOOL_RECRUIT,HIDDEN_GEM)'}
+
+        res = self._fetch(f"/jobs/jobPostings/{job_id}", params=params)
+
+        data = res.json()
+
+        if data and "status" in data and data["status"] != 200:
+            self.logger.info("request failed, code {}".format(data["status"]))
+            return {}
+
+        return data
+
     def get_conversation_details(self, profile_urn_id):
         """
         Return the conversation (or "message thread") details for a given [public_profile_id]

--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -528,7 +528,9 @@ class Linkedin(object):
             "topNRequestedFlavors": "List(IN_NETWORK,COMPANY_RECRUIT,SCHOOL_RECRUIT,HIDDEN_GEM)",
         }
 
-        res = self._fetch(f"/jobs/jobPostings/{job_urn_id}", params=params)
+        res = self._fetch(
+            f"/jobs/jobPostings/{job_urn_id}?{urlencode(params, safe='(),')}"
+        )
 
         data = res.json()
 

--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -522,8 +522,11 @@ class Linkedin(object):
         Return job posting details for a given [job_urn_id], e.g: 1677638156
         """
 
-        params = {'decorationId': 'com.linkedin.voyager.deco.jobs.web.shared.WebFullJobPosting-39', 'topN': '1',
-                  'topNRequestedFlavors': 'List(IN_NETWORK,COMPANY_RECRUIT,SCHOOL_RECRUIT,HIDDEN_GEM)'}
+        params = {
+            "decorationId": "com.linkedin.voyager.deco.jobs.web.shared.WebFullJobPosting-39",
+            "topN": "1",
+            "topNRequestedFlavors": "List(IN_NETWORK,COMPANY_RECRUIT,SCHOOL_RECRUIT,HIDDEN_GEM)",
+        }
 
         res = self._fetch(f"/jobs/jobPostings/{job_urn_id}", params=params)
 

--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -517,15 +517,15 @@ class Linkedin(object):
 
         return company
 
-    def get_job_posting(self, job_id):
+    def get_job_posting(self, job_urn_id):
         """
-        Return job posting details for a given [job_id], e.g: 1677638156
+        Return job posting details for a given [job_urn_id], e.g: 1677638156
         """
 
         params = {'decorationId': 'com.linkedin.voyager.deco.jobs.web.shared.WebFullJobPosting-39', 'topN': '1',
                   'topNRequestedFlavors': 'List(IN_NETWORK,COMPANY_RECRUIT,SCHOOL_RECRUIT,HIDDEN_GEM)'}
 
-        res = self._fetch(f"/jobs/jobPostings/{job_id}", params=params)
+        res = self._fetch(f"/jobs/jobPostings/{job_urn_id}", params=params)
 
         data = res.json()
 


### PR DESCRIPTION
This method returns job posting details. The job_urn_id can be found in the "jobPosting" fields in the response of a linkedin.search for job postings,e.g:
```
      "jobPosting": "urn:li:fs_normalized_jobPosting:1754968923",
```