### PR TITLE
Fix search and more

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -82,7 +82,8 @@ Returns a Linkedin profile's first degree (direct) connections
 
 **Arguments**
 
-- `urn_id <str>` - id provided by the Linkedin URN
+- `urn_id <str>` - id provided by the Linkedin URN.
+  If `urn_id` is `None`, returns the currently authenticated profile's connections.
 
 **Return**
 

--- a/README.md
+++ b/README.md
@@ -10,30 +10,14 @@
 
 Programmatically send messages, perform searches, get profile data and more, all with a regular Linkedin user account!
 
-Before using this project, please consult the [Terms and Conditions](#t-c) and [Legal Notice](#legal).
-
-## Overview
-
-This project attempts to provide a simple Python interface for the Linkedin API.
-
-> Do you mean the [legit Linkedin API](https://developer.linkedin.com/)?
-
-NO! To retrieve structured data, the [Linkedin Website](https://linkedin.com) uses a service they call **Voyager**. Voyager endpoints give us access to pretty much everything we could want from Linkedin: profiles, companies, connections, messages, etc. - anything that you can see on linkedin.com, we can get from Voyager.
-
-So specifically, this project aims to provide complete coverage for Voyager.
-
-[How do we do it?](#in-depth-overview)
-
-### Want to contribute?
-
-[Learn how to find endpoints](#to-find-endpoints)
+Before using this project, please consult the [Terms and Conditions](#terms-and-conditions) and [Legal Notice](#legal).
 
 ## Installation
 
-Using **Python >= 3.6**:
+> ⚠️ Python >= 3.6 required
 
-```
-$ pip install -e git+https://github.com/tomquirk/linkedin-api.git
+```bash
+pip install -e git+https://github.com/tomquirk/linkedin-api.git
 ```
 
 ### Example usage
@@ -58,60 +42,74 @@ connections = api.get_profile_connections('1234asc12304')
 
 For a complete reference documentation, see the [DOCS.md](https://github.com/tomquirk/linkedin-api/blob/master/DOCS.md)
 
+## Overview
+
+This project attempts to provide a simple Python interface for the Linkedin API.
+
+> Do you mean the [legit Linkedin API](https://developer.linkedin.com/)?
+
+NO! To retrieve structured data, the [Linkedin Website](https://linkedin.com) uses a service they call **Voyager**. Voyager endpoints give us access to pretty much everything we could want from Linkedin: profiles, companies, connections, messages, etc. - anything that you can see on linkedin.com, we can get from Voyager.
+
+So specifically, this project aims to provide complete coverage for Voyager.
+
+[How do we do it?](#in-depth-overview)
+
+### How to contribute
+
+[Learn how to find endpoints](#to-find-endpoints)
+
 ## Development Setup
 
 ### Dependencies
 
 - Python 3.7
 - A valid Linkedin user account (don't use your personal account, if possible)
-- Pipenv (optional)
+- `pipenv` (optional)
 
-### Installation
+### Development installation
 
 1. Create a `.env` config file. An example is provided in `.env.example` - you include at least all of the settings set there.
 2. Using pipenv...
 
-   ```
-   $ pipenv install --dev
-   $ pipenv shell
+   ```bash
+   pipenv install --dev
+   pipenv shell
    ```
 
 ### Running tests
 
-```
-$ python -m pytest tests
+```bash
+python -m pytest tests
 ```
 
 ### Troubleshooting
 
-#### > I keep getting a CHALLENGE!?!
+#### I keep getting a `CHALLENGE`
 
 Linkedin will throw you a curve ball in the form of a Challenge URL. We currently don't handle this, and so you're kinda screwed. We think it could be only IP-based (i.e. logging in from different location). Your best chance at resolution is to log out and log back in on your browser.
 
-##### Known reasons for Challenge:
+**Known reasons for Challenge** include:
 
 - 2FA
 - Rate-limit - "It looks like you’re visiting a very high number of pages on LinkedIn.". Note - n=1 experiment where this page was hit after ~900 contiguous requests in a single session (within the hour) (these included random delays between each request), as well as a bunch of testing, so who knows the actual limit.
 
 Please add more as you come across them.
 
-#### Search woes
+#### Search problems
 
 - Mileage may vary when searching general keywords like "software" using the standard `search` method. They've recently added some smarts around search whereby they group results by people, company, jobs etc. if the query is general enough. Try to use an entity-specific search method (i.e. search_people) where possible.
-
-<a name="in-depth-overview"></a>
 
 ## In-depth overview
 
 Voyager endpoints look like this:
 
-```
+```text
 https://www.linkedin.com/voyager/api/identity/profileView/tom-quirk
 ```
 
 Or, more clearly
 
-```
+```text
  ___________________________________ _______________________________
 |             base path             |            resource           |
 https://www.linkedin.com/voyager/api /identity/profileView/tom-quirk
@@ -121,9 +119,7 @@ They are authenticated with a simple cookie, which we send with every request, a
 
 To get a cookie, we POST a given username and password (of a valid Linkedin user account) to `https://www.linkedin.com/uas/authenticate`.
 
-<a name="to-find-endpoints"></a>
-
-### To find endpoints...
+### To find endpoints
 
 We're looking at the Linkedin website and we spot some data we want. What now?
 
@@ -132,12 +128,14 @@ The most reliable method to find the relevant endpoint is to:
 1. `view source`
 2. `command-f`/search the page for some keyword in the data. This will exist inside of a `<code>` tag.
 3. Scroll down to the **next adjacent element** which will be another `<code>` tag, probably with an `id` that looks something like
+
    ```html
    <code style="display: none" id="datalet-bpr-guid-3900675">
      {"request":"/voyager/api/identity/profiles/tom-quirk/profileView","status":200,"body":"bpr-guid-3900675"}
    </code>
    ```
-4. The value of `request` is the url! :woot:
+
+4. The value of `request` is the url! 🤘
 
 You can also use the `network` tab in you browsers developer tools, but you will encounter mixed results.
 
@@ -147,13 +145,13 @@ Linkedin seems to have developed an internal query language/syntax where Clients
 
 Here's an example of making a request for an organisation's `name` and `groups` (the Linkedin groups it manages):
 
-```
+```text
 /voyager/api/organization/companies?decoration=(name,groups*~(entityUrn,largeLogo,groupName,memberCount,websiteUrl,url))&q=universalName&universalName=linkedin
 ```
 
 The "querying" happens in the `decoration` parameter, which looks like
 
-```
+```text
 (
     name,
     groups*~(entityUrn,largeLogo,groupName,memberCount,websiteUrl,url)
@@ -166,13 +164,11 @@ Different endpoints use different parameters (and perhaps even different syntaxe
 
 In contrast, the `/search/cluster` endpoint uses `q=guided`, and specifies its query with the `guided` parameter, whose value is something like
 
-```
+```text
 List(v->PEOPLE)
 ```
 
 It could be possible to document (and implement a nice interface for) this query language - as we add more endpoints to this project, I'm sure it will become more clear if such a thing would be possible (and if it's worth it).
-
-<a name="t-c"></a>
 
 ## Terms and Conditions
 
@@ -187,10 +183,8 @@ This project may not be used for any of the following:
 - Storage of any Personally Identifiable Information
 - Personal abuse (i.e. verbal abuse)
 
-<a name="legal"></a>
-
 ## Legal
 
 This code is in no way affiliated with, authorized, maintained, sponsored or endorsed by Linkedin or any of its affiliates or subsidiaries. This is an independent and unofficial API. Use at your own risk.
 
-This project violates Linkedin's User Agreement Section 8.2, and because of this, Linkedin may (and will) temporarily or permantly ban your account. We are not responsible for your account being banned.
+This project violates Linkedin's User Agreement Section 8.2, and because of this, Linkedin may (and will) temporarily or permanently ban your account. We are not responsible for your account being banned.

--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -69,7 +69,7 @@ class Linkedin(object):
         url = f"{self.client.API_BASE_URL}{uri}"
         return self.client.session.post(url, **kwargs)
 
-    def search(self, params, limit=None, results=[]):
+    def search(self, params, limit=None):
         """
         Do a search.
         """
@@ -78,48 +78,45 @@ class Linkedin(object):
             if limit and limit <= Linkedin._MAX_SEARCH_COUNT
             else Linkedin._MAX_SEARCH_COUNT
         )
-        default_params = {
-            "count": str(count),
-            "filters": "List()",
-            "origin": "GLOBAL_SEARCH_HEADER",
-            "q": "all",
-            "start": len(results),
-            "queryContext": "List(spellCorrectionEnabled->true,relatedSearchesEnabled->true,kcardTypes->PROFILE|COMPANY)",
-        }
 
-        default_params.update(params)
+        results = []
+        while True:
+            default_params = {
+                "count": str(count),
+                "filters": "List()",
+                "origin": "GLOBAL_SEARCH_HEADER",
+                "q": "all",
+                "start": len(results),
+                "queryContext": "List(spellCorrectionEnabled->true,relatedSearchesEnabled->true,kcardTypes->PROFILE|COMPANY)",
+            }
+            default_params.update(params)
 
-        res = self._fetch(
-            f"/search/blended?{urlencode(default_params, safe='(),')}",
-            headers={"accept": "application/vnd.linkedin.normalized+json+2.1"},
-        )
-
-        data = res.json()
-
-        new_elements = []
-        for i in range(len(data["data"]["elements"])):
-            new_elements.extend(data["data"]["elements"][i]["elements"])
-            # not entirely sure what extendedElements generally refers to - keyword search gives back a single job?
-            # new_elements.extend(data["data"]["elements"][i]["extendedElements"])
-
-        results.extend(new_elements)
-        results = results[
-            :limit
-        ]  # always trim results, no matter what the request returns
-
-        # recursive base case
-        if (
-            limit is not None
-            and (
-                len(results) >= limit  # if our results exceed set limit
-                or len(results) / count >= Linkedin._MAX_REPEATED_REQUESTS
+            res = self._fetch(
+                f"/search/blended?{urlencode(default_params, safe='(),')}",
+                headers={"accept": "application/vnd.linkedin.normalized+json+2.1"},
             )
-        ) or len(new_elements) == 0:
-            return results
+            data = res.json()
 
-        self.logger.debug(f"results grew to {len(results)}")
+            new_elements = []
+            for i in range(len(data["data"]["elements"])):
+                new_elements.extend(data["data"]["elements"][i]["elements"])
+                # not entirely sure what extendedElements generally refers to - keyword search gives back a single job?
+                # new_elements.extend(data["data"]["elements"][i]["extendedElements"])
+            results.extend(new_elements)
 
-        return self.search(params, results=results, limit=limit)
+            # break the loop if we're done searching
+            if (
+                limit is not None
+                and (
+                    len(results) >= limit  # if our results exceed set limit
+                    or len(results) / count >= Linkedin._MAX_REPEATED_REQUESTS
+                )
+            ) or len(new_elements) == 0:
+                break
+
+            self.logger.debug(f"results grew to {len(results)}")
+
+        return results
 
     def search_people(
         self,

--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -27,7 +27,7 @@ class Linkedin(object):
     """
 
     _MAX_UPDATE_COUNT = 100  # max seems to be 100
-    _MAX_SEARCH_COUNT = 49  # max seems to be 49
+    _MAX_SEARCH_COUNT = 49  # max seems to be 49, and min seems to be 2
     _MAX_REPEATED_REQUESTS = (
         200  # VERY conservative max requests count to avoid rate-limit
     )
@@ -81,6 +81,9 @@ class Linkedin(object):
 
         results = []
         while True:
+            # when we're close to the limit, only fetch what we need to
+            if limit - len(results) < count:
+                count = limit - len(results)
             default_params = {
                 "count": str(count),
                 "filters": "List()",
@@ -105,6 +108,8 @@ class Linkedin(object):
             results.extend(new_elements)
 
             # break the loop if we're done searching
+            # NOTE: we could also check for the `total` returned in the response.
+            # This is in data["data"]["paging"]["total"]
             if (
                 limit is not None
                 and (
@@ -417,9 +422,10 @@ class Linkedin(object):
 
         return profile
 
-    def get_profile_connections(self, urn_id):
+    def get_profile_connections(self, urn_id=None):
         """
-        Return a list of profile ids connected to profile of given [urn_id]
+        Return a list of profile ids connected to profile of given [urn_id].
+        If urn_id is None, then the currently logged in user's connections are returned
         """
         return self.search_people(connection_of=urn_id, network_depth="F")
 

--- a/tests/test_linkedin_api_requests.py
+++ b/tests/test_linkedin_api_requests.py
@@ -126,6 +126,13 @@ def test_search(linkedin):
     assert results
 
 
+def test_search_pagination(linkedin):
+    linkedin._MAX_SEARCH_COUNT = 2
+    results = linkedin.search({"keywords": "software"}, limit=4)
+    assert results
+    assert len(results) == 4
+
+
 def test_search_with_limit(linkedin):
     results = linkedin.search({"keywords": "tom"}, limit=1)
     assert len(results) == 1


### PR DESCRIPTION
* Fix search
* Improve search performance by only fetching the remaining count as search approaches `limit`
* get_profile_connections now optionally accepts urn_id. If none is provided, it will get connections of currently authed user

Possibly helps https://github.com/tomquirk/linkedin-api/issues/64, https://github.com/tomquirk/linkedin-api/issues/88