### PR TITLE
`search_people` using the `Keywords` filter

### DIFF
--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -138,6 +138,12 @@ class Linkedin(object):
         title=None,
         include_private_profiles=False,  # profiles without a public id, "Linkedin Member"
         limit=None,
+        # Keywords filter
+        keyword_first_name=None,
+        keyword_last_name=None,
+        keyword_title=None,
+        keyword_company=None,
+        keyword_school=None,
     ):
         """
         Do a people search.
@@ -163,6 +169,16 @@ class Linkedin(object):
             filters.append(f'schools->{"|".join(schools)}')
         if title:
             filters.append(f"title->{title}")
+        if keyword_first_name:
+            filters.append(f"firstName->{keyword_first_name}")
+        if keyword_last_name:
+            filters.append(f"lastName->{keyword_last_name}")
+        if keyword_title:
+            filters.append(f"title->{keyword_title}")
+        if keyword_company:
+            filters.append(f"company->{keyword_company}")
+        if keyword_school:
+            filters.append(f"school->{keyword_school}")
 
         params = {"filters": "List({})".format(",".join(filters))}
 

--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -130,13 +130,13 @@ class Linkedin(object):
         regions=None,
         industries=None,
         schools=None,
-        title=None,
+        title=None,  # `keyword_title` and `title` are the same. We kept `title` for backward compatibility. Please only use one of them.
         include_private_profiles=False,  # profiles without a public id, "Linkedin Member"
         limit=None,
         # Keywords filter
         keyword_first_name=None,
         keyword_last_name=None,
-        keyword_title=None,
+        keyword_title=None,  # `keyword_title` and `title` are the same. We kept `title` for backward compatibility. Please only use one of them.
         keyword_company=None,
         keyword_school=None,
     ):
@@ -162,8 +162,8 @@ class Linkedin(object):
             filters.append(f'nonprofitInterest->{"|".join(nonprofit_interests)}')
         if schools:
             filters.append(f'schools->{"|".join(schools)}')
-        if title:
-            filters.append(f"title->{title}")
+        # `Keywords` filter
+        keyword_title = keyword_title if keyword_title else title
         if keyword_first_name:
             filters.append(f"firstName->{keyword_first_name}")
         if keyword_last_name:

--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -73,11 +73,9 @@ class Linkedin(object):
         """
         Do a search.
         """
-        count = (
-            limit
-            if limit and limit <= Linkedin._MAX_SEARCH_COUNT
-            else Linkedin._MAX_SEARCH_COUNT
-        )
+        if not limit or limit > Linkedin._MAX_SEARCH_COUNT:
+            limit = Linkedin._MAX_SEARCH_COUNT
+        count = limit
 
         results = []
         while True:
@@ -111,11 +109,8 @@ class Linkedin(object):
             # NOTE: we could also check for the `total` returned in the response.
             # This is in data["data"]["paging"]["total"]
             if (
-                limit is not None
-                and (
-                    len(results) >= limit  # if our results exceed set limit
-                    or len(results) / count >= Linkedin._MAX_REPEATED_REQUESTS
-                )
+                len(results) >= limit  # if our results exceed set limit
+                or len(results) / count >= Linkedin._MAX_REPEATED_REQUESTS
             ) or len(new_elements) == 0:
                 break
 

--- a/tests/test_linkedin_api_requests.py
+++ b/tests/test_linkedin_api_requests.py
@@ -156,6 +156,14 @@ def test_search_people_by_region(linkedin):
     assert results[0]["public_id"]
 
 
+def test_search_people_by_keywords_filter(linkedin: Linkedin):
+    results = linkedin.search_people(
+        keyword_first_name="John", keyword_last_name="Smith"
+    )
+    assert results
+    assert results[0]["public_id"]
+
+
 def test_search_jobs(linkedin):
     jobs = linkedin.search_jobs(keywords="data analyst", location="Germany", count=1)
 


### PR DESCRIPTION
Hi, small PR here :

1. I added the possibility to search people using the Keywords filters from LinkedIn which are super helpful (see screenshot below)

![Screenshot from 2020-06-23 14-42-53](https://user-images.githubusercontent.com/60365279/85404895-e531fb00-b55f-11ea-83b5-8ecc97487416.png)

2. I fixed what I think was an issue where `limit` could be `None` which would result in a `TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'` error (please review this change to make sure I didn't break the previous logic even though I don't think so)