### PR TITLE
Grant possibility to get full profile picture url

### DIFF
--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -354,9 +354,21 @@ class Linkedin(object):
         profile = data["profile"]
         if "miniProfile" in profile:
             if "picture" in profile["miniProfile"]:
+                # profile picture url prefix (root url)
                 profile["displayPictureUrl"] = profile["miniProfile"]["picture"][
                     "com.linkedin.common.VectorImage"
                 ]["rootUrl"]
+                # profile pictures full urls dict (prefix: root Url + suffix: artifcat)
+                # example : {"100_100": "https://medi...100_100/0?e=15984...", "200_200": ...}
+                profile["displayPictureFullUrls"] = {
+                    f"{suffix['width']}_{suffix['height']}": profile[
+                        "displayPictureUrl"
+                    ]
+                    + suffix["fileIdentifyingUrlPathSegment"]
+                    for suffix in profile["miniProfile"]["picture"][
+                        "com.linkedin.common.VectorImage"
+                    ]["artifacts"]
+                }
             profile["profile_id"] = get_id_from_urn(profile["miniProfile"]["entityUrn"])
             profile["profile_urn"] = profile["miniProfile"]["entityUrn"]
 


### PR DESCRIPTION
Hey, another quick contribution ^^ I might do a few more, in case I bump into a few more needs/issues, since I'm working on a project using the library at the moment :)

As stated in my comment here https://github.com/tomquirk/linkedin-api/issues/93, I don't see how to get the profile pictures without actually changing the `get_profile` code, so here is a PR to fix this ;)

We now have a new key in the `get_profile` dict response : 

```
{
    ...,
    "displayPictureUrl": ...
    "displayPictureFullUrls": {
        "100_100": "https://medi...100_100/0?e=15984...", # You can browse to this url and actually get the picture
         "200_200": ...
    }
}
```

I kept the `displayPictureUrl` for backwards compatibility.

Regarding the tests, I'm not too sure whether they're still used since I'm getting errors using the example values in `.env.example` (Im speaking about the 3 `urn_id` values in that file). Anyways, I did a manual test for two profiles (one with a picture and another one without any picture and it seems fine :+1:) 

Let me know if I should change anything.
