### PR TITLE
Handle explicitly passed None value

### DIFF
--- a/linkedin_api/cookie_repository.py
+++ b/linkedin_api/cookie_repository.py
@@ -21,8 +21,8 @@ class CookieRepository(object):
     TODO: refactor to use http.cookiejar.FileCookieJar
     """
 
-    def __init__(self, cookies_dir=settings.COOKIE_PATH):
-        self.cookies_dir = cookies_dir
+    def __init__(self, cookies_dir=None):
+        self.cookies_dir = cookies_dir if cookies_dir else settings.COOKIE_PATH
 
     def save(self, cookies, username):
         self._ensure_cookies_dir()


### PR DESCRIPTION
Hi, @tomquirk 

In this PR, I fixed an unexpected behavior introduced after #128 with 97ba02654ea8809548181e6ed7fb3fa8a2909091.

If user does not provide a `cookies_dir` while instantiating an `Linkedin` instance, `Client` explicitly sends `None` to the `CookieRepository` and `cookies_dir` is set `None` instead of `settings.COOKIE_PATH` which is the default value.

This results with a `TypeError` as mentioned in https://github.com/tomquirk/linkedin-api/issues/129. `TypeError` occurs while calling `os.path.exists` with `None` in `CookieRepository._ensure_cookies_dir`. 

I added a conditional to the `CookieRepository` constructor. This solution brings backs the capability to use the default cookies directory in `settings.py`.

Fixes #129