### PR TITLE
[Bug][search_people] Network_depths using result of network_depth

### DIFF
--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -226,7 +226,7 @@ class Linkedin(object):
         if connection_of:
             filters.append(f"connectionOf->{connection_of}")
         if network_depths:
-            filters.append(f'network->{"|".join(network_depth)}')
+            filters.append(f'network->{"|".join(network_depths)}')
         elif network_depth:
             filters.append(f"network->{network_depth}")
         if regions:


### PR DESCRIPTION
## Summary
```
api = Linkedin(<USERNAME>, <PASSWORD>)
api.search_people(keyword_first_name="Raymond", keyword_last_name="Guo", keyword_school="Stanford University", network_depths=("F","S"))
Traceback (most recent call last):
  File "<pyshell#60>", line 1, in <module>
    api.search_people(keyword_first_name="Raymond", keyword_last_name="Guo", keyword_school="Stanford University", network_depths=("F","S"))
  File "/usr/local/lib/python3.8/site-packages/linkedin_api/linkedin.py", line 218, in search_people
    filters.append(f'network->{"|".join(network_depth)}')
TypeError: can only join an iterable
```
The issue was that linkedin.py was trying to join `network_depth` not `network_depths`
## Tests
I retested with that command, and it worked.