### PR TITLE
Add LinkedIn projects to scraped data

### DIFF
--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -704,6 +704,12 @@ class Linkedin(object):
             del item["entityUrn"]
         profile["honors"] = honors
 
+        # massage [projects] data
+        projects = data["projectView"]["elements"]
+        for item in projects:
+            del item["entityUrn"]
+        profile["projects"] = projects
+
         return profile
 
     def get_profile_connections(self, urn_id):


### PR DESCRIPTION
Hi, 

I'm using this library to scrape some LinkedIn profiles but I wanted to get their projects as well. Would be great to get this merged in, and down the line maybe a more configurable API that lets the caller select which bits of the LinkedIn profile they want to select?

Thanks for building this!