### PR TITLE
Added option to get multiple degree connection

### DIFF
--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -1439,3 +1439,98 @@ class Linkedin(object):
             limit, offset, exclude_promoted_posts
         )
         return get_list_posts_sorted_without_promoted(l_urns, l_posts)
+
+    def send_bulk_message(
+        self,
+        keywords=None,
+        connection_message = "",
+        first_degree_message= "",
+        connection_of=None,
+        network_depths=None,
+        current_company=None,
+        past_companies=None,
+        nonprofit_interests=None,
+        profile_languages=None,
+        regions=None,
+        industries=None,
+        schools=None,
+        contact_interests=None,
+        service_categories=None,
+        include_private_profiles=False,  # profiles without a public id, "Linkedin Member"
+        # Keywords filter
+        keyword_first_name=None,
+        keyword_last_name=None,
+        # `keyword_title` and `title` are the same. We kept `title` for backward compatibility. Please only use one of them.
+        keyword_title=None,
+        keyword_company=None,
+        keyword_school=None,
+        network_depth=None,  # DEPRECATED - use network_depths
+        title=None,  # DEPRECATED - use keyword_title
+        limit = -1,
+        **kwargs,
+    ):
+        """Perform a LinkedIn search for people.
+
+        :param first_degree_message: message send to first degree connection
+        :type first_degree_message: str, optional
+        :param connection_message: message send to second or third degree connection
+        :type connection_message: str, optional
+        :param limit: limit of user send message
+        :type limit: int, optional
+        :param keywords: Keywords to search on
+        :type keywords: str, optional
+        :param current_company: A list of company URN IDs (str)
+        :type current_company: list, optional
+        :param past_companies: A list of company URN IDs (str)
+        :type past_companies: list, optional
+        :param regions: A list of geo URN IDs (str)
+        :type regions: list, optional
+        :param industries: A list of industry URN IDs (str)
+        :type industries: list, optional
+        :param schools: A list of school URN IDs (str)
+        :type schools: list, optional
+        :param profile_languages: A list of 2-letter language codes (str)
+        :type profile_languages: list, optional
+        :param contact_interests: A list containing one or both of "proBono" and "boardMember"
+        :type contact_interests: list, optional
+        :param service_categories: A list of service category URN IDs (str)
+        :type service_categories: list, optional
+        :param network_depth: Deprecated, use `network_depths`. One of "F", "S" and "O" (first, second and third+ respectively)
+        :type network_depth: str, optional
+        :param network_depths: A list containing one or many of "F", "S" and "O" (first, second and third+ respectively)
+        :type network_depths: list, optional
+        :param include_private_profiles: Include private profiles in search results. If False, only public profiles are included. Defaults to False
+        :type include_private_profiles: boolean, optional
+        :param keyword_first_name: First name
+        :type keyword_first_name: str, optional
+        :param keyword_last_name: Last name
+        :type keyword_last_name: str, optional
+        :param keyword_title: Job title
+        :type keyword_title: str, optional
+        :param keyword_company: Company name
+        :type keyword_company: str, optional
+        :param keyword_school: School name
+        :type keyword_school: str, optional
+        :param connection_of: Connection of LinkedIn user, given by profile URN ID
+        :type connection_of: str, optional
+
+        :return: List of success and failure message
+        :rtype: list
+        """
+        result = self.search_people(keywords, connection_of, network_depths, current_company, past_companies, nonprofit_interests,
+                                    profile_languages, regions, industries, schools, contact_interests, service_categories, include_private_profiles,
+                                    keyword_first_name, keyword_last_name, keyword_title, keyword_company, keyword_school, network_depth, title,
+                                    limit = limit)
+
+        output = []
+        for data in result:
+            try:
+                if data['distance']!='DISTANCE_1':
+                    self.add_connection(data['public_id'], connection_message)
+                else:
+                    self.send_message( message_body= first_degree_message, recipients=[data['urn_id']])
+                output.append( "For user id {0} message send successfully".format(data['public_id']))
+            except Exception as ex:
+                output.append("For user id {0} message not send due to error {1}".format(data['public_id'],ex))
+
+        return output

--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -712,16 +712,19 @@ class Linkedin(object):
 
         return profile
 
-    def get_profile_connections(self, urn_id):
-        """Fetch first-degree connections for a given LinkedIn profile.
+    def get_profile_connections(self, urn_id, network_depth= "F"):
+        """By Default it will fetch first-degree connections for a given LinkedIn profile.
 
         :param urn_id: LinkedIn URN ID for a profile
+        :type urn_id: str
+
+        :param network_depth: degree of connection for a given Linkedin profile
         :type urn_id: str
 
         :return: List of search results
         :rtype: list
         """
-        return self.search_people(connection_of=urn_id, network_depth="F")
+        return self.search_people(connection_of=urn_id, network_depth= network_depth)
 
     def get_company_updates(
         self, public_id=None, urn_id=None, max_results=None, results=[]


### PR DESCRIPTION
**1 Change Description** 
- Added option to get multiple degree connection based on network_depth.  
- Valid network_depth value is (F,S,T).
- First Degree (F), Second Degree(S), Third Degree (T).
- By default network_depth value is "F".

- Added feature to send bulk message to first, second and third degree connection.
- If first degree connection then direct send message.
- If second or third degree connection then send message with add connection request.


**2.  Testing Details:-**
- Tested end to end by fetching first, second and third degree connection. 
- Test send bulk message with first, second and third degree connection and with various test cases.