### PR TITLE
get_company_updates and get_profile_updates: optimize use of max_results

### DIFF
--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -724,7 +724,7 @@ class Linkedin(object):
         return self.search_people(connection_of=urn_id, network_depth="F")
 
     def get_company_updates(
-        self, public_id=None, urn_id=None, max_results=None, results=[]
+        self, public_id=None, urn_id=None, max_results=None, results=None
     ):
         """Fetch company updates (news activity) for a given LinkedIn company.
 
@@ -736,6 +736,9 @@ class Linkedin(object):
         :return: List of company update objects
         :rtype: list
         """
+        if results is None:
+            results = []
+
         params = {
             "companyUniversalName": {public_id or urn_id},
             "q": "companyFeedByUniversalName",
@@ -747,6 +750,7 @@ class Linkedin(object):
         res = self._fetch(f"/feed/updates", params=params)
 
         data = res.json()
+        results.extend(data["elements"])
 
         if (
             len(data["elements"]) == 0
@@ -756,9 +760,8 @@ class Linkedin(object):
                 and len(results) / max_results >= Linkedin._MAX_REPEATED_REQUESTS
             )
         ):
-            return results
+            return results[:max_results]
 
-        results.extend(data["elements"])
         self.logger.debug(f"results grew: {len(results)}")
 
         return self.get_company_updates(
@@ -769,7 +772,7 @@ class Linkedin(object):
         )
 
     def get_profile_updates(
-        self, public_id=None, urn_id=None, max_results=None, results=[]
+        self, public_id=None, urn_id=None, max_results=None, results=None
     ):
         """Fetch profile updates (newsfeed activity) for a given LinkedIn profile.
 
@@ -781,6 +784,9 @@ class Linkedin(object):
         :return: List of profile update objects
         :rtype: list
         """
+        if results is None:
+            results = []
+
         params = {
             "profileId": {public_id or urn_id},
             "q": "memberShareFeed",
@@ -792,6 +798,7 @@ class Linkedin(object):
         res = self._fetch(f"/feed/updates", params=params)
 
         data = res.json()
+        results.extend(data["elements"])
 
         if (
             len(data["elements"]) == 0
@@ -801,9 +808,8 @@ class Linkedin(object):
                 and len(results) / max_results >= Linkedin._MAX_REPEATED_REQUESTS
             )
         ):
-            return results
+            return results[:max_results]
 
-        results.extend(data["elements"])
         self.logger.debug(f"results grew: {len(results)}")
 
         return self.get_profile_updates(


### PR DESCRIPTION
1. do not set [] as a default parameter, as it is a global list and if the method is called twice, previous results will be included
2. extend results *before* checking if results limit is reached, it prevents useless API calls
3. return only required results