### PR TITLE
Documented optional `limit` parameter to `search_people` function

### DIFF
--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -315,6 +315,8 @@ class Linkedin(object):
         :type keyword_school: str, optional
         :param connection_of: Connection of LinkedIn user, given by profile URN ID
         :type connection_of: str, optional
+        :param limit: Maximum length of the returned list, defaults to -1 (no limit)
+        :type limit: int, optional
 
         :return: List of profiles (minimal data only)
         :rtype: list


### PR DESCRIPTION
I noticed that search_people is a wrapper function around search and has a default parameter limit=-1. Since search accepts arbitrary keyword arguments, this means that you can also pass limit to search_people.

I've updated the documentation to reflect this, explaining that search_people can accept an optional limit parameter with a default value of -1.