### PR TITLE
fix: change `search` to use graphql new endpoint

### DIFF
--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -14,6 +14,7 @@ from linkedin_api.client import Client
 from linkedin_api.utils.helpers import (
     append_update_post_field_to_posts_list,
     get_id_from_urn,
+    get_urn_from_raw_update,
     get_list_posts_sorted_without_promoted,
     get_update_author_name,
     get_update_author_profile,
@@ -224,18 +225,50 @@ class Linkedin(object):
             default_params.update(params)
 
             res = self._fetch(
-                f"/search/blended?{urlencode(default_params, safe='(),')}",
-                headers={"accept": "application/vnd.linkedin.normalized+json+2.1"},
+                f"/graphql?variables=(start:{default_params['start']},origin:{default_params['origin']},"
+                f"query:(keywords:{default_params['keywords']},flagshipSearchIntent:SEARCH_SRP,"
+                f"queryParameters:{default_params['filters']},"
+                f"includeFiltersInResponse:false))&=&queryId=voyagerSearchDashClusters"
+                f".b0928897b71bd00a5a7291755dcd64f0"
             )
             data = res.json()
 
-            new_elements = []
-            elements = data.get("data", {}).get("elements", [])
+            data_clusters = data.get("data", []).get("searchDashClustersByAll", [])
 
-            for element in elements:
-                new_elements.extend(element.get("elements", {}))
-                # not entirely sure what extendedElements generally refers to - keyword search gives back a single job?
-                # new_elements.extend(data["data"]["elements"][i]["extendedElements"])
+            if not data_clusters:
+                return []
+
+            if (
+                not data_clusters.get("_type", [])
+                == "com.linkedin.restli.common.CollectionResponse"
+            ):
+                return []
+
+            new_elements = []
+            for it in data_clusters.get("elements", []):
+                if (
+                    not it.get("_type", [])
+                    == "com.linkedin.voyager.dash.search.SearchClusterViewModel"
+                ):
+                    continue
+
+                for el in it.get("items", []):
+                    if (
+                        not el.get("_type", [])
+                        == "com.linkedin.voyager.dash.search.SearchItem"
+                    ):
+                        continue
+
+                    e = el.get("item", []).get("entityResult", [])
+                    if not e:
+                        continue
+                    if (
+                        not e.get("_type", [])
+                        == "com.linkedin.voyager.dash.search.EntityResultViewModel"
+                    ):
+                        continue
+                    new_elements.append(e)
+
             results.extend(new_elements)
 
             # break the loop if we're done searching
@@ -249,7 +282,7 @@ class Linkedin(object):
 
             self.logger.debug(f"results grew to {len(results)}")
 
-        return results
+            return results
 
     def search_people(
         self,
@@ -316,44 +349,53 @@ class Linkedin(object):
         :param connection_of: Connection of LinkedIn user, given by profile URN ID
         :type connection_of: str, optional
 
-        :return: List of profiles (minimal data only: keys ["urn_id", "distance", "public_id", "tracking_id", "jobtitle", "location", "name"])
+        :return: List of profiles (minimal data only)
         :rtype: list
         """
-        filters = ["resultType->PEOPLE"]
+        filters = ["(key:resultType,value:List(PEOPLE))"]
         if connection_of:
-            filters.append(f"connectionOf->{connection_of}")
+            filters.append(f"(key:connectionOf,value:List({connection_of}))")
         if network_depths:
-            filters.append(f'network->{"|".join(network_depths)}')
+            stringify = " | ".join(network_depths)
+            filters.append(f"(key:network,value:List({stringify}))")
         elif network_depth:
-            filters.append(f"network->{network_depth}")
+            filters.append(f"(key:network,value:List({network_depth}))")
         if regions:
-            filters.append(f'geoUrn->{"|".join(regions)}')
+            stringify = " | ".join(regions)
+            filters.append(f"(key:geoUrn,value:List({stringify}))")
         if industries:
-            filters.append(f'industry->{"|".join(industries)}')
+            stringify = " | ".join(industries)
+            filters.append(f"(key:industry,value:List({stringify}))")
         if current_company:
-            filters.append(f'currentCompany->{"|".join(current_company)}')
+            stringify = " | ".join(current_company)
+            filters.append(f"(key:currentCompany,value:List({stringify}))")
         if past_companies:
-            filters.append(f'pastCompany->{"|".join(past_companies)}')
+            stringify = " | ".join(past_companies)
+            filters.append(f"(key:pastCompany,value:List({stringify}))")
         if profile_languages:
-            filters.append(f'profileLanguage->{"|".join(profile_languages)}')
+            stringify = " | ".join(profile_languages)
+            filters.append(f"(key:profileLanguage,value:List({stringify}))")
         if nonprofit_interests:
-            filters.append(f'nonprofitInterest->{"|".join(nonprofit_interests)}')
+            stringify = " | ".join(nonprofit_interests)
+            filters.append(f"(key:nonprofitInterest,value:List({stringify}))")
         if schools:
-            filters.append(f'schools->{"|".join(schools)}')
+            stringify = " | ".join(schools)
+            filters.append(f"(key:schools,value:List({stringify}))")
         if service_categories:
-            filters.append(f'serviceCategory->{"|".join(service_categories)}')
+            stringify = " | ".join(service_categories)
+            filters.append(f"(key:serviceCategory,value:List({stringify}))")
         # `Keywords` filter
         keyword_title = keyword_title if keyword_title else title
         if keyword_first_name:
-            filters.append(f"firstName->{keyword_first_name}")
+            filters.append(f"(key:firstName,value:List({keyword_first_name}))")
         if keyword_last_name:
-            filters.append(f"lastName->{keyword_last_name}")
+            filters.append(f"(key:lastName,value:List({keyword_last_name}))")
         if keyword_title:
-            filters.append(f"title->{keyword_title}")
+            filters.append(f"(key:title,value:List({keyword_title}))")
         if keyword_company:
-            filters.append(f"company->{keyword_company}")
+            filters.append(f"(key:company,value:List({keyword_company}))")
         if keyword_school:
-            filters.append(f"school->{keyword_school}")
+            filters.append(f"(key:school,value:List({keyword_school}))")
 
         params = {"filters": "List({})".format(",".join(filters))}
 
@@ -364,17 +406,25 @@ class Linkedin(object):
 
         results = []
         for item in data:
-            if not include_private_profiles and "publicIdentifier" not in item:
+            if (
+                not include_private_profiles
+                and (item.get("entityCustomTrackingInfo") or {}).get(
+                    "memberDistance", None
+                )
+                == "OUT_OF_NETWORK"
+            ):
                 continue
             results.append(
                 {
-                    "urn_id": get_id_from_urn(item.get("targetUrn")),
-                    "distance": item.get("memberDistance", {}).get("value"),
-                    "public_id": item.get("publicIdentifier"),
-                    "tracking_id": get_id_from_urn(item.get("trackingUrn")),
-                    "jobtitle": item.get("headline", {}).get("text"),
-                    "location": item.get("subline", {}).get("text"),
-                    "name": item.get("title", {}).get("text"),
+                    "urn_id": get_id_from_urn(
+                        get_urn_from_raw_update(item.get("entityUrn", None))
+                    ),
+                    "distance": (item.get("entityCustomTrackingInfo") or {}).get(
+                        "memberDistance", None
+                    ),
+                    "jobtitle": (item.get("primarySubtitle") or {}).get("text", None),
+                    "location": (item.get("secondarySubtitle") or {}).get("text", None),
+                    "name": (item.get("title") or {}).get("text", None),
                 }
             )
 
@@ -389,7 +439,7 @@ class Linkedin(object):
         :return: List of companies
         :rtype: list
         """
-        filters = ["resultType->COMPANIES"]
+        filters = ["(key:resultType,value:List(COMPANIES))"]
 
         params = {
             "filters": "List({})".format(",".join(filters)),
@@ -403,15 +453,14 @@ class Linkedin(object):
 
         results = []
         for item in data:
-            if item.get("type") != "COMPANY":
+            if "company" not in item.get("trackingUrn"):
                 continue
             results.append(
                 {
-                    "urn": item.get("targetUrn"),
-                    "urn_id": get_id_from_urn(item.get("targetUrn")),
-                    "name": item.get("title", {}).get("text"),
-                    "headline": item.get("headline", {}).get("text"),
-                    "subline": item.get("subline", {}).get("text"),
+                    "urn_id": get_id_from_urn(item.get("trackingUrn", None)),
+                    "name": (item.get("title") or {}).get("text", None),
+                    "headline": (item.get("primarySubtitle") or {}).get("text", None),
+                    "subline": (item.get("secondarySubtitle") or {}).get("text", None),
                 }
             )
 
@@ -743,10 +792,10 @@ class Linkedin(object):
         :return: List of company update objects
         :rtype: list
         """
-        
+
         if results is None:
             results = []
-        
+
         params = {
             "companyUniversalName": {public_id or urn_id},
             "q": "companyFeedByUniversalName",
@@ -792,10 +841,10 @@ class Linkedin(object):
         :return: List of profile update objects
         :rtype: list
         """
-        
+
         if results is None:
             results = []
-            
+
         params = {
             "profileId": {public_id or urn_id},
             "q": "memberShareFeed",
@@ -1367,7 +1416,6 @@ class Linkedin(object):
         l_urns = []
 
         while True:
-
             # when we're close to the limit, only fetch what we need to
             if limit > -1 and limit - len(l_urns) < count:
                 count = limit - len(l_urns)


### PR DESCRIPTION
As discussed in this issue: https://github.com/tomquirk/linkedin-api/issues/313#issue-1726611738, `search` endpoint has changed in Linkedin, breaking `search_people` and `search_companies` endpoints that use it.

I basically took the solutions of [17314642](https://github.com/tomquirk/linkedin-api/issues/313#issuecomment-1574333025) and [Timur-Gizatullin](https://github.com/tomquirk/linkedin-api/issues/313#issuecomment-1578338809) and modified a few things.

There are some fields that were previously extracted in `serach_people` that I couldn't find in the new elements retrieved. There might be cleaner ways to fix this issue so feel free to suggest or add any changes!