### PR TITLE
[Fix] Remove `{self.client.API_BASE_URL}` from `reply_invitation()` POST URL

### DIFF
--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -1168,7 +1168,7 @@ class Linkedin(object):
         )
 
         res = self._post(
-            f"{self.client.API_BASE_URL}/relationships/invitations/{invitation_id}",
+            f"/relationships/invitations/{invitation_id}",
             params=params,
             data=payload,
         )


### PR DESCRIPTION
Fixes https://github.com/tomquirk/linkedin-api/issues/351

As it says in the issue, it appears this function's URL construction string just had an extra variable that was causing it to return 404s. I put it in line with the other functions and tested it successfully with my own project. 

It now works as intended and responds appropriately to invitations.

Perhaps there was some reason for the `{self.client.API_BASE_URL}`, but I suspect it was just left behind in a refactor. 