### PR TITLE
Fix There are multiple cookies with name, 'JSESSIONID'

### DIFF
--- a/linkedin_api/client.py
+++ b/linkedin_api/client.py
@@ -78,9 +78,12 @@ class Client(object):
 
     def _set_session_cookies(self, cookies):
         """
-        Set cookies of the current session and save them to a file named as the username.
+        Set cookies of the current session, but reuse the existing JSESSIONID if it's already set.
         """
-        self.session.cookies = cookies
+        existing_jsessionid = self.session.cookies.get("JSESSIONID", None)
+        if existing_jsessionid is None:
+            self.session.cookies = cookies
+        
         self.session.headers["csrf-token"] = self.session.cookies["JSESSIONID"].strip(
             '"'
         )


### PR DESCRIPTION
An attempt to address this error
```
There are multiple cookies with name, 'JSESSIONID'
```

If there's an existing cookie, just reuse it