### PR TITLE
docs: fix typo (bleading -> bleeding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ And more! [Read the docs](https://linkedin-api.readthedocs.io/en/latest/api.html
 pip install linkedin-api
 ```
 
-Or, for bleading edge:
+Or, for bleeding edge:
 
 ```bash
 pip install git+https://github.com/tomquirk/linkedin-api.git


### PR DESCRIPTION
"Definitions from Wiktionary (blead) ▸ verb: Obsolete spelling of bleed. [(intransitive, of a person, animal or body part) To shed blood through an injured blood vessel.] ▸ verb: Misspelling of bleed. [(intransitive, of a person, animal or body part) To shed blood through an injured blood vessel.]"