### PR TITLE
fix: Use quote instead of encode for job search

### DIFF
--- a/linkedin_api/linkedin.py
+++ b/linkedin_api/linkedin.py
@@ -635,10 +635,16 @@ class Linkedin(object):
                 "start": len(results) + offset,
             }
 
+            query_params = "&".join(
+                f"{quote(str(key))}={quote(str(value), safe='(),:')}"
+                for key, value in default_params.items()
+            )
+
             res = self._fetch(
-                f"/voyagerJobsDashJobCards?{urlencode(default_params, safe='(),:')}",
+                f"/voyagerJobsDashJobCards?{query_params}",
                 headers={"accept": "application/vnd.linkedin.normalized+json+2.1"},
             )
+
             data = res.json()
 
             elements = data.get("included", [])


### PR DESCRIPTION
For job search, use quote instead of encode. Now users can filter LinkedIn searches—for example, using -senior will remove all jobs that contain "senior" in the description or title. This didn't work before because when performing a search, encode replaced spaces with "+", which is a special character in LinkedIn search.